### PR TITLE
Issue #11: Add prop "first day of week"

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ yarn add vue-renderless-calendar
 | captureThirdDate     | false       | Boolean               | false               | `captureThirdDate` prop is used for capturing dates between in case when 2 dates already selected and you have third element hovered
 | disabledDates        | false       | Array<String>         | []                  | Array of `YYYY-MM-DDD` strings containing dates that can't be selected |
 | markedDates          | false       | Array<String>         | []                  | Array of `YYYY-MM-DDD` strings with special meaning, that later will be accessed via `isMarked` modifier |
+| firstDayOfWeek       | false       | number                | 1                   | Index of the weekday to start the week from. From 0 to 6. 0 is Sunday, 6 is Saturday |
 
 
 ### Scoped-slots properties
@@ -70,7 +71,7 @@ yarn add vue-renderless-calendar
 | Property             | Type     | Description
 |----------------------|----------|---------------
 | isSelected           | Boolean  |
-| isBetween           | Boolean  |
+| isBetween            | Boolean  |
 | isDisabled           | Boolean  |
 | isMarked             | Boolean  |
 | isFirst              | Boolean  | is first selected date

--- a/example/App.vue
+++ b/example/App.vue
@@ -16,22 +16,22 @@
             <input v-model="customLocale">
           </span>
         </p>
-        <Calendar :locale="customLocale" :first-day-of-week="customLocale === 'en' ? 0 : 1" />
+        <Calendar :locale="customLocale" />
       </section>
-      <!-- <section>
+      <section>
         <p>
           Hard-coded locale <i>(backward-compatible)</i>
           <pre>/lib/locale/ru.js</pre>
         </p>
         <Calendar :locale="hardcodedLocale" />
-      </section> -->
+      </section>
     </div>
-    <!-- <section>
+    <section>
       <DoubleCalendar :locale="customLocale" />
     </section>
     <section>
       <InfiniteCalendar locale="de-DE" />
-    </section> -->
+    </section>
   </div>
 </template>
 
@@ -49,7 +49,8 @@ export default {
     Calendar
   },
   data: () => ({
-    customLocale: 'en'
+    hardcodedLocale: localeRu,
+    customLocale: 'hu'
   })
 };
 </script>

--- a/example/App.vue
+++ b/example/App.vue
@@ -6,9 +6,9 @@
           Localized with <i>.toLocalString()</i>
           <span class="flex buttons">
             <button
-              v-for="loc in ['fr', 'de', 'es', 'ar', 'pl']"
+              v-for="loc in ['fr', 'de', 'es', 'en', 'pl']"
               :key="loc"
-              :class="{active: loc===customLocale}"
+              :class="{active: loc === customLocale}"
               @click="customLocale = loc"
             >
               {{ loc }}
@@ -16,22 +16,22 @@
             <input v-model="customLocale">
           </span>
         </p>
-        <Calendar :locale="customLocale" />
+        <Calendar :locale="customLocale" :first-day-of-week="customLocale === 'en' ? 0 : 1" />
       </section>
-      <section>
+      <!-- <section>
         <p>
           Hard-coded locale <i>(backward-compatible)</i>
           <pre>/lib/locale/ru.js</pre>
         </p>
         <Calendar :locale="hardcodedLocale" />
-      </section>
+      </section> -->
     </div>
-    <section>
+    <!-- <section>
       <DoubleCalendar :locale="customLocale" />
     </section>
     <section>
       <InfiniteCalendar locale="de-DE" />
-    </section>
+    </section> -->
   </div>
 </template>
 
@@ -49,8 +49,7 @@ export default {
     Calendar
   },
   data: () => ({
-    hardcodedLocale: localeRu,
-    customLocale: 'hu'
+    customLocale: 'en'
   })
 };
 </script>

--- a/example/components/Calendar.vue
+++ b/example/components/Calendar.vue
@@ -68,11 +68,7 @@
       CalendarCell
     },
     props: {
-      locale: [String, Object],
-      firstDayOfWeek: {
-        type: Number,
-        default: 0
-      }
+      locale: [String, Object]
     },
     data() {
       return {
@@ -80,6 +76,11 @@
         maxDate: '2022-06-26',
         disabledDates: ['2019-05-30', '2019-06-12', '2019-06-20']
       };
+    },
+    computed: {
+      firstDayOfWeek() {
+        return this.locale === 'en' ? 0 : 1;
+      }
     },
     methods: {
       handleDateChange(payload) {

--- a/example/components/Calendar.vue
+++ b/example/components/Calendar.vue
@@ -18,6 +18,7 @@
     :disabled-dates="disabledDates"
     :marked-dates="['2019-05-29']"
     :locale="locale"
+    :first-day-of-week="firstDayOfWeek"
     prevent-out-of-range
     mode="range"
     @onDateChange="handleDateChange"
@@ -67,12 +68,16 @@
       CalendarCell
     },
     props: {
-      locale: [String, Object]
+      locale: [String, Object],
+      firstDayOfWeek: {
+        type: Number,
+        default: 0
+      }
     },
     data() {
       return {
         minDate: '2019-06-01',
-        maxDate: '2020-06-26',
+        maxDate: '2022-06-26',
         disabledDates: ['2019-05-30', '2019-06-12', '2019-06-20']
       };
     },

--- a/example/components/Calendar.vue
+++ b/example/components/Calendar.vue
@@ -3,12 +3,13 @@
     v-slot="{
       getModifiers,
       selectedDates,
-      currentYear,
       prevPage,
       nextPage,
       weekDayNames,
       monthNames,
       calendar,
+      canGoToPrevMonth,
+      canGoToNextMonth,
       onDateMouseOut,
       onDateMouseOver,
       onDateSelect
@@ -32,11 +33,11 @@
         :data-date-2="selectedDates[1] && selectedDates[1].formatted"
       >
         <div class="calendar__header">
-          <button class="calendar__month-btn" @click="prevPage"></button>
+          <button class="calendar__month-btn" :disabled="!canGoToPrevMonth" @click="prevPage"></button>
           <span class="calendar__title" style="text-transform:capitalize">
             {{ monthNames[view.month].full }}, <strong style="font-weight: 800;">{{ view.year }}</strong>
           </span>
-          <button class="calendar__month-btn" @click="nextPage"></button>
+          <button class="calendar__month-btn" :disabled="!canGoToNextMonth" @click="nextPage"></button>
         </div>
         <div class="calendar__weeks">
           <span v-for="day in weekDayNames" :key="day.short" class="calendar__week-day">
@@ -160,6 +161,11 @@
       &:focus {
         outline: none;
         background-color: darken($light-gray, 10%);
+      }
+
+      &:disabled {
+        cursor: auto;
+        background-color: aliceblue;
       }
     }
     

--- a/example/components/DoubleCalendar.vue
+++ b/example/components/DoubleCalendar.vue
@@ -25,6 +25,7 @@
     :capture-hover="captureHover"
     :mode="mode"
     prevent-out-of-range
+    :first-day-of-week="firstDayOfWeek"
     :default-selected-dates="dates"
     view-mode="double"
     @onDateChange="handleDateChange"
@@ -85,17 +86,22 @@
       CalendarCell
     },
     props: { 
-      locale: String 
+      locale: String
     },
     data() {
       return {
         minDate: '2019-06-01',
-        maxDate: '2020-06-26',
+        maxDate: '2022-06-26',
         disabledDates: ['2019-05-30', '2019-06-12', '2019-06-20'],
         mode: 'range',
         captureHover: true,
         dates: ['2020-01-30', '2020-02-05']
       };
+    },
+    computed: {
+      firstDayOfWeek() {
+        return this.locale === 'en' ? 0 : 1;
+      }
     },
     methods: {
       handleDateChange(dates) {

--- a/example/components/InfiniteCalendar.vue
+++ b/example/components/InfiniteCalendar.vue
@@ -27,6 +27,7 @@
       mode="range"
       view-mode="custom"
       :default-selected-dates="['2019-06-14', '2019-06-28']"
+      :first-day-of-week="firstDayOfWeek"
       @onDateChange="handleDateChange"
     >
       <div class="root" :class="isOpened ? 'infinite-calendar' : ''">
@@ -82,6 +83,11 @@
         disabledDates: ['2019-05-30', '2019-06-12', '2019-06-20'],
         isOpened: false
       };
+    },
+    computed: {
+      firstDayOfWeek() {
+        return this.locale === 'en' ? 0 : 1;
+      }
     },
     methods: {
       handleDateChange(payload) {

--- a/lib/RenderlessCalendar.js
+++ b/lib/RenderlessCalendar.js
@@ -89,6 +89,10 @@ export default {
     markedDates: {
       type: Array,
       default: () => []
+    },
+    firstDayOfWeek: {
+      type: Number,
+      default: 1
     }
   },
 
@@ -116,7 +120,8 @@ export default {
       numberOfMonths: this.customNumberOfMonths,
       month: this.currentMonth,
       viewMode: this.viewMode,
-      year: this.currentYear
+      year: this.currentYear,
+      firstDayOfWeek: this.firstDayOfWeek
     }));
   },
 
@@ -126,17 +131,15 @@ export default {
      */
     localeStrings() {
       return typeof this.locale === 'string'
-        ? getCalendarStringsForLocale(this.locale)
+        ? getCalendarStringsForLocale(this.locale, this.firstDayOfWeek)
         : this.locale;
     },
     weekDayNames() {
-      // @ts-ignore
       return this.localeStrings.days;
     },
     monthNames() {
-      // @ts-ignore
       return this.localeStrings.months
-        .map((month, id) => ({ short: month.short, full: month.full, id }));
+        .map(({ short, full }, id) => ({ short, full, id }));
     },
     monthsList() {
       return getMonthsList({
@@ -211,7 +214,8 @@ export default {
         numberOfMonths: customNumberOfMonths,
         year: prevMonthDate.getFullYear(),
         month: prevMonthDate.getMonth(),
-        viewMode
+        viewMode,
+        firstDayOfWeek: this.firstDayOfWeek
       });
 
       if (viewMode === VIEW_MODE_SINGLE) {
@@ -255,7 +259,8 @@ export default {
         numberOfMonths: customNumberOfMonths,
         year: nextMonthDate.getFullYear(),
         month: nextMonthDate.getMonth(),
-        viewMode
+        viewMode,
+        firstDayOfWeek: this.firstDayOfWeek
       });
 
       if (viewMode === VIEW_MODE_SINGLE) {
@@ -305,7 +310,8 @@ export default {
         numberOfMonths: customNumberOfMonths,
         viewMode,
         month,
-        year
+        year,
+        firstDayOfWeek: this.firstDayOfWeek
       });
       this.viewState = newViewState;
     },
@@ -387,6 +393,16 @@ export default {
         this.dateChangeHangler = this.dateSelectStrategy || getDateSelectStrategy(mode);
       },
       immediate: true
+    },
+    firstDayOfWeek(newFirstDoW) {
+      const [{ month, year }] = this.viewState;
+      this.calendar = Object.freeze(generateCalendarViewData({
+        numberOfMonths: this.customNumberOfMonths,
+        viewMode: this.viewMode,
+        firstDayOfWeek: newFirstDoW,
+        month,
+        year
+      }));
     },
     defaultSelectedDates(dates) {
       this.selectedDates = dates.map(CalendarDate.fromString);

--- a/lib/classes/CalendarDate.js
+++ b/lib/classes/CalendarDate.js
@@ -8,9 +8,9 @@ import {
 } from '../utils/renderless-date.service';
 
 export default function CalendarDate(year, month, day, {
-  isOtherMonthDay = false,
-  firstDayOfWeek = 1
-} = {}) {
+  isOtherMonthDay,
+  firstDayOfWeek
+} = { isOtherMonthDay: false, firstDayOfWeek: 1 }) {
   const date = new Date(year, month, day);
 
   this.ms = date.valueOf();
@@ -31,7 +31,7 @@ export default function CalendarDate(year, month, day, {
   this.isOtherMonthDay = isOtherMonthDay;
 }
 
-CalendarDate.fromString = function (date, { firstDayOfWeek = 1 }) {
+CalendarDate.fromString = function (date, { firstDayOfWeek } = { firstDayOfWeek: 1 }) {
   const [year, month, day] = date.split('-');
   return new CalendarDate(year, month - MONTH_INDEX_CORRECTION, day, { firstDayOfWeek });
 };

--- a/lib/classes/CalendarDate.js
+++ b/lib/classes/CalendarDate.js
@@ -14,7 +14,7 @@ export default function CalendarDate(year, month, day, {
 
   this.ms = date.valueOf();
 
-  this.dayOfWeek = (date.getDay() + 6) % 7;
+  this.dayOfWeek = date.getDay();
 
   this.year = date.getFullYear();
   this.month = date.getMonth();

--- a/lib/classes/CalendarDate.js
+++ b/lib/classes/CalendarDate.js
@@ -1,4 +1,4 @@
-import { MONTH_INDEX_CORRECTION } from '../utils/constants';
+import { MONTH_INDEX_CORRECTION, DAYS_IN_WEEK } from '../utils/constants';
 import { prependZero } from '../utils/fns';
 import {
   isSelected,
@@ -8,13 +8,15 @@ import {
 } from '../utils/renderless-date.service';
 
 export default function CalendarDate(year, month, day, {
-  isOtherMonthDay = false
+  isOtherMonthDay = false,
+  firstDayOfWeek = 1
 } = {}) {
   const date = new Date(year, month, day);
 
   this.ms = date.valueOf();
 
-  this.dayOfWeek = date.getDay();
+  // + DAYS_IN_WEEK avoids having negative number in the modulo (-1 % 7 -> 6 % 7)
+  this.dayOfWeek = (date.getDay() - firstDayOfWeek + DAYS_IN_WEEK) % DAYS_IN_WEEK;
 
   this.year = date.getFullYear();
   this.month = date.getMonth();
@@ -29,9 +31,9 @@ export default function CalendarDate(year, month, day, {
   this.isOtherMonthDay = isOtherMonthDay;
 }
 
-CalendarDate.fromString = function (date) {
+CalendarDate.fromString = function (date, { firstDayOfWeek = 1 }) {
   const [year, month, day] = date.split('-');
-  return new CalendarDate(year, month - MONTH_INDEX_CORRECTION, day);
+  return new CalendarDate(year, month - MONTH_INDEX_CORRECTION, day, { firstDayOfWeek });
 };
 
 CalendarDate.prototype.isBetween = function ({

--- a/lib/utils/constants.js
+++ b/lib/utils/constants.js
@@ -1,6 +1,7 @@
 export const MAX_DAYS_IN_YEAR = 366;
 export const MAX_DAYS_IN_MONTH = 31;
 export const NUMBER_OF_MONTHS = 12;
+export const DAYS_IN_WEEK = 7;
 export const ZERO_BASED_DAYS_IN_WEEK = 6;
 
 export const MONTH_INDEX_CORRECTION = 1;

--- a/lib/utils/locale-strings.js
+++ b/lib/utils/locale-strings.js
@@ -1,3 +1,5 @@
+import { DAYS_IN_WEEK } from './constants';
+
 const CALENDAR_STRINGS = {};
 /**
  * @typedef {{
@@ -26,7 +28,7 @@ export function getCalendarStringsForLocale(locale, firstDayOfWeek) {
  * @return {LocaleStrings}
  */
 function generateLocaleStrings(locale, firstDayOfWeek = 1) {
-  const validFirstDayOfWeek = firstDayOfWeek % 7;
+  const validFirstDayOfWeek = firstDayOfWeek % DAYS_IN_WEEK;
 
   const today = new Date();
   const year = today.getFullYear();

--- a/lib/utils/locale-strings.js
+++ b/lib/utils/locale-strings.js
@@ -7,23 +7,27 @@ const CALENDAR_STRINGS = {};
  */
 /**
  * @param {string} locale
+ * @param {number} firstDayOfWeek Index of weekday to start the week from (0: sunday, 6: Saturday)
  * @return {LocaleStrings}
  */
-export function getCalendarStringsForLocale(locale) {
+export function getCalendarStringsForLocale(locale, firstDayOfWeek) {
   if (!(/^[a-z]{2,3}(-[A-Za-z]{2})?$/).test(locale)) {
     locale = navigator.language;
   }
   if (!CALENDAR_STRINGS.hasOwnProperty(locale)) {
-    CALENDAR_STRINGS[locale] = generateLocaleStrings(locale);
+    CALENDAR_STRINGS[locale] = generateLocaleStrings(locale, firstDayOfWeek);
   }
   return CALENDAR_STRINGS[locale];
 }
 
 /**
  * @param {string} locale
+ * @param {number} firstDayOfWeek Index of weekday to start the week from (0: sunday, 6: Saturday)
  * @return {LocaleStrings}
  */
-function generateLocaleStrings(locale) {
+function generateLocaleStrings(locale, firstDayOfWeek = 1) {
+  const validFirstDayOfWeek = firstDayOfWeek % 7;
+
   const today = new Date();
   const year = today.getFullYear();
   const month = today.getMonth();
@@ -36,7 +40,9 @@ function generateLocaleStrings(locale) {
       full: d.toLocaleString(locale, { month: 'long' })
     };
   });
-  const firstMondayDate = today.getDate() - day + (day === 0 ? -6 : 1);
+  // Get day number - index of current weekday + the weekday index we want to start from
+  // ex: 16 (16th in the month) - 2 (it's a Tuesday) = 14 (previous Sunday number) => + 1 to go to next Monday
+  const firstMondayDate = today.getDate() - day + validFirstDayOfWeek;
   const days = [...Array(7)].map((_, i) => {
     const d = new Date(year, month, firstMondayDate + i);
     return {

--- a/lib/utils/locale-strings.js
+++ b/lib/utils/locale-strings.js
@@ -35,7 +35,7 @@ function generateLocaleStrings(locale, firstDayOfWeek = 1) {
   const month = today.getMonth();
   const day = today.getDay();
 
-  const months = [...Array(12)].map((_, i) => {
+  const months = Array(12).fill().map((_, i) => {
     const d = new Date(year, i);
     return {
       short: d.toLocaleString(locale, { month: 'short' }),
@@ -45,7 +45,7 @@ function generateLocaleStrings(locale, firstDayOfWeek = 1) {
   // Get day number - index of current weekday + the weekday index we want to start from
   // ex: 16 (16th in the month) - 2 (it's a Tuesday) = 14 (previous Sunday number) => + 1 to go to next Monday
   const firstMondayDate = today.getDate() - day + validFirstDayOfWeek;
-  const days = [...Array(7)].map((_, i) => {
+  const days = Array(7).fill().map((_, i) => {
     const d = new Date(year, month, firstMondayDate + i);
     return {
       short: d.toLocaleString(locale, { weekday: 'short' }),

--- a/lib/utils/renderless-calendar.service.js
+++ b/lib/utils/renderless-calendar.service.js
@@ -5,7 +5,13 @@ import {
   VIEW_MODE_CUSTOM,
   ZERO_BASED_DAYS_IN_WEEK
 } from './constants';
-import { getMonthDateSafely, isEqual, isGreaterThan, isLessThan, isSameMonth } from './renderless-date.service';
+import {
+  getMonthDateSafely,
+  isEqual,
+  isGreaterThan,
+  isLessThan,
+  isSameMonth
+} from './renderless-date.service';
 import CalendarDate from '../classes/CalendarDate';
 
 const monthsEnum = {
@@ -35,7 +41,7 @@ export function generateCalendarViewData({
     const year = nextMonthDate.getFullYear();
     const month = nextMonthDate.getMonth();
 
-    const currentMonthDates = getCurrentMonthDates(year, month);
+    const currentMonthDates = getCurrentMonthDates(year, month, firstDayOfWeek);
     const prevMonthDates = getPrevMonthDates(currentMonthDates[0], firstDayOfWeek);
     const nextMonthDates = getNextMonthDates(currentMonthDates[currentMonthDates.length - 1], firstDayOfWeek);
 
@@ -54,33 +60,33 @@ export function generateCalendarViewData({
 }
 
 
-export function getPrevMonthDates(date, firstDayOfWeek) {
-  return _getMonthLastNDays(date.dayOfWeek - firstDayOfWeek, date.year, date.month);
+export function getPrevMonthDates(date, firstDayOfWeek = 1) {
+  return _getMonthLastNDays(date.dayOfWeek, date.year, date.month, { firstDayOfWeek });
 }
 
-export function getCurrentMonthDates(year, month) {
+export function getCurrentMonthDates(year, month, firstDayOfWeek = 1) {
   const dates = [];
 
   for (let day = 1; day <= MAX_DAYS_IN_MONTH; day++) {
-    dates.push(new CalendarDate(year, month, day));
+    dates.push(new CalendarDate(year, month, day, { firstDayOfWeek }));
   }
 
   return dates.filter(date => isSameMonth(month, date.month));
 }
 
-export function getNextMonthDates(date, firstDayOfWeek) {
-  const numberOfDays = ZERO_BASED_DAYS_IN_WEEK - date.dayOfWeek + firstDayOfWeek;
-  return _getMonthFirstNDays(numberOfDays, date.year, date.month);
+export function getNextMonthDates(date, firstDayOfWeek = 1) {
+  const numberOfDays = ZERO_BASED_DAYS_IN_WEEK - date.dayOfWeek;
+  return _getMonthFirstNDays(numberOfDays, date.year, date.month, { firstDayOfWeek });
 }
 
-export function _getMonthLastNDays(n, year, month) {
+export function _getMonthLastNDays(n, year, month, firstDayOfWeek = 1) {
   const dates = [];
   const prevMonthNumber = month - 1;
 
   let dayNumber = MAX_DAYS_IN_MONTH;
 
-  while (dates.length !== n) {
-    const date = new CalendarDate(year, prevMonthNumber, dayNumber, { isOtherMonthDay: true });
+  while (dates.length < n) {
+    const date = new CalendarDate(year, prevMonthNumber, dayNumber, { isOtherMonthDay: true, firstDayOfWeek });
 
     if (!isSameMonth(month, date.month)) {
       dates.unshift(date);
@@ -92,12 +98,12 @@ export function _getMonthLastNDays(n, year, month) {
   return dates;
 }
 
-export function _getMonthFirstNDays(n, year, month) {
+export function _getMonthFirstNDays(n, year, month, firstDayOfWeek = 1) {
   const dates = [];
   const nextMonthNumber = month + 1;
 
   for (let dayNumber = 1; dayNumber <= n; dayNumber++) {
-    const date = new CalendarDate(year, nextMonthNumber, dayNumber, { isOtherMonthDay: true });
+    const date = new CalendarDate(year, nextMonthNumber, dayNumber, { isOtherMonthDay: true, firstDayOfWeek });
     dates.push(date);
   }
 

--- a/lib/utils/renderless-calendar.service.js
+++ b/lib/utils/renderless-calendar.service.js
@@ -17,7 +17,8 @@ export function generateCalendarViewData({
   numberOfMonths,
   viewMode,
   month,
-  year
+  year,
+  firstDayOfWeek
 }) {
   const months = viewMode === VIEW_MODE_CUSTOM
     ? numberOfMonths
@@ -35,8 +36,8 @@ export function generateCalendarViewData({
     const month = nextMonthDate.getMonth();
 
     const currentMonthDates = getCurrentMonthDates(year, month);
-    const prevMonthDates = getPrevMonthDates(currentMonthDates[0]);
-    const nextMonthDates = getNextMonthDates(currentMonthDates[currentMonthDates.length - 1]);
+    const prevMonthDates = getPrevMonthDates(currentMonthDates[0], firstDayOfWeek);
+    const nextMonthDates = getNextMonthDates(currentMonthDates[currentMonthDates.length - 1], firstDayOfWeek);
 
     result.push({
       dates: [...prevMonthDates, ...currentMonthDates, ...nextMonthDates],
@@ -53,8 +54,8 @@ export function generateCalendarViewData({
 }
 
 
-export function getPrevMonthDates(date) {
-  return _getMonthLastNDays(date.dayOfWeek, date.year, date.month);
+export function getPrevMonthDates(date, firstDayOfWeek) {
+  return _getMonthLastNDays(date.dayOfWeek - firstDayOfWeek, date.year, date.month);
 }
 
 export function getCurrentMonthDates(year, month) {
@@ -67,8 +68,8 @@ export function getCurrentMonthDates(year, month) {
   return dates.filter(date => isSameMonth(month, date.month));
 }
 
-export function getNextMonthDates(date) {
-  const numberOfDays = ZERO_BASED_DAYS_IN_WEEK - date.dayOfWeek;
+export function getNextMonthDates(date, firstDayOfWeek) {
+  const numberOfDays = ZERO_BASED_DAYS_IN_WEEK - date.dayOfWeek + firstDayOfWeek;
   return _getMonthFirstNDays(numberOfDays, date.year, date.month);
 }
 


### PR DESCRIPTION
Hi there!

I just added a new property to the `RenderlessCalendar` component : `first-day-of-week`.
It is intended to configure the... first day of the week. A week could start by Sunday for example.

I followed the specifications given by many other calendar libraries out there, and also the official Javascript `Date.prototype.getDay()` method: **0 is Sunday, 6 is Saturday.**

In order to keep the default behaviour of the component, I set the default value of the prop to `1` (= Monday).

----------

I tested the component manually with the current Calendar examples.

Also, I increased the example date range so that it goes up to 2022. Or we'll see only disabled dates on the examples!
And I fixed some potential cases of infinite loops (on the while loop, it happened while I developed).

----------

Fixes #11.