### PR TITLE
Default props values

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ yarn add vue-renderless-calendar
 |----------------------|-------------|-----------------------|---------------------|----------------------------------
 | viewMode             | false       | String                |                     | 'single', 'double', 'infinite'
 | mode                 | false       | String                |                     | 'single', 'range'
-| locale               | false       | Object or String      | navigator.language  | Locale string (e.g. 'ru'), it will automatically generate locale object using `Date.prototype.toLocaleString`, otherwise you can provide this object manually 
+| locale               | false       | Object or String      | navigator.language (client), 'en' (server)  | Locale string (e.g. 'ru'), it will automatically generate locale object using `Date.prototype.toLocaleString`, otherwise you can provide this object manually 
 | minDate              | false       | String                | ''                  | Minimal valid date (`YYYY-MM-DDD`)
 | maxDate              | false       | String                | ''                  | Maximal valid date (`YYYY-MM-DDD`)
 | preventOutOfRange    | false       | Boolean               | true                | Prevent user go out of valid dates range

--- a/lib/RenderlessCalendar.js
+++ b/lib/RenderlessCalendar.js
@@ -56,11 +56,11 @@ export default {
     },
     minDate: {
       type: String,
-      default: ''
+      default: null
     },
     maxDate: {
       type: String,
-      default: ''
+      default: null
     },
     preventOutOfRange: {
       default: true,

--- a/lib/utils/locale-strings.js
+++ b/lib/utils/locale-strings.js
@@ -11,7 +11,7 @@ const CALENDAR_STRINGS = {};
  */
 export function getCalendarStringsForLocale(locale) {
   if (!(/^[a-z]{2,3}(-[A-Za-z]{2})?$/).test(locale)) {
-    locale = navigator.language;
+    locale = navigator ? navigator.language : 'en';
   }
   if (!CALENDAR_STRINGS.hasOwnProperty(locale)) {
     CALENDAR_STRINGS[locale] = generateLocaleStrings(locale);

--- a/lib/utils/renderless-calendar.service.js
+++ b/lib/utils/renderless-calendar.service.js
@@ -113,6 +113,8 @@ export function shouldPreventMonthChange({
 }
 
 export function breaksLowerLimit(minDate, currentYear, currentMonth) {
+  if (!minDate) { return false; }
+
   const [year, month, day] = minDate.split('-');
   const date = new Date(year, month - MONTH_INDEX_CORRECTION, day);
   const minDateYear = date.getFullYear();
@@ -123,6 +125,8 @@ export function breaksLowerLimit(minDate, currentYear, currentMonth) {
 }
 
 export function breaksUpperLimit(maxDate, currentYear, currentMonth) {
+  if (!maxDate) { return false; }
+
   const [year, month, day] = maxDate.split('-');
   const date = new Date(year, month - MONTH_INDEX_CORRECTION, day);
   const maxDateYear = date.getFullYear();

--- a/lib/utils/renderless-calendar.service.test.js
+++ b/lib/utils/renderless-calendar.service.test.js
@@ -32,4 +32,14 @@ test('shouldPreventMonthChange', t => {
   });
 
   t.is(result, false);
+
+  result = renderlessCalendarService.shouldPreventMonthChange({
+    currentYear: 2019,
+    currentMonth: 8,
+    maxDate: null,
+    minDate: null,
+    step: -1
+  });
+
+  t.is(result, false);
 });

--- a/lib/utils/renderless-date.service.js
+++ b/lib/utils/renderless-date.service.js
@@ -80,5 +80,5 @@ export function isRestricted(date, {
 }) {
   return (minDate && isLessThan(date, minDate))
     || (maxDate && isGreaterThan(date, maxDate))
-    || (isDisabled(date, disabledDates));
+    || isDisabled(date, disabledDates);
 }


### PR DESCRIPTION
* Allow `minDate` and `maxDate` properties to be `null` instead of using an empty string
* Defaults locale to 'en' if `navigator` doesn't exists. This is to be SSR compliant.