### PR TITLE
Adding sourcemaps to debug

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "rollup": "^1.15.1",
     "rollup-plugin-babel": "^4.3.2",
     "rollup-plugin-buble": "^0.19.2",
+    "rollup-plugin-sourcemaps": "^0.6.3",
     "rollup-plugin-terser": "^5.2.0",
     "sass-loader": "^7.1.0",
     "vue": "^2.6.10",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,5 +1,6 @@
 import { terser } from 'rollup-plugin-terser';
 import buble from 'rollup-plugin-buble';
+import sourcemaps from 'rollup-plugin-sourcemaps';
 import fs from 'fs';
 import path from 'path';
 
@@ -33,17 +34,20 @@ export default [{
   input: path.join('lib', 'index.js'),
   output: [
     {
+      sourcemap: true,
       format: 'es',
       dir: 'dist',
       entryFileNames: '[name].es.js'
     },
     {
+      sourcemap: true,
       format: 'cjs',
       dir: 'dist'
     }
   ],
   plugins: [
     buble(),
+    sourcemaps(),
     production && terser()
   ]
 }, ...locales];

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -34,20 +34,20 @@ export default [{
   input: path.join('lib', 'index.js'),
   output: [
     {
-      sourcemap: true,
+      sourcemap: !production,
       format: 'es',
       dir: 'dist',
       entryFileNames: '[name].es.js'
     },
     {
-      sourcemap: true,
+      sourcemap: !production,
       format: 'cjs',
       dir: 'dist'
     }
   ],
   plugins: [
     buble(),
-    sourcemaps(),
+    !production && sourcemaps(),
     production && terser()
   ]
 }, ...locales];


### PR DESCRIPTION
I've been debugging a lot the library lately and adding sourcemaps have been really helpful.

They are only included in the bundle on dev mode (i.e. not production mode).

It allows us to debug the js sources directly in the browser's console :)