### PR TITLE
Fix classes order + select hovered date

### DIFF
--- a/lib/RenderlessCalendar.js
+++ b/lib/RenderlessCalendar.js
@@ -317,7 +317,9 @@ export default {
       });
     },
     isSelected(date) {
-      return date.isSelected(this.selectedDates);
+      const isSelectingRange = this.currentHoveredDate && this.mode === MODE_RANGE && this.selectedDates.length === 1;
+      return date.isSelected(this.selectedDates)
+        || (isSelectingRange && date.formatted === this.currentHoveredDate.formatted);
     },
     isDisabled(date) {
       return isRestricted(date.formatted, {
@@ -329,16 +331,16 @@ export default {
     isOneDayAfter(date) {
       return this.selectedDates
         .map(_ => _.formatted)
-        .some(formatted => isNextDate(formatted, date.formatted));
+        .some(formatted => isNextDate(date.formatted, formatted));
     },
     isOneDayBefore(date) {
       return this.selectedDates
         .map(_ => _.formatted)
-        .some(formatted => isPrevDate(formatted, date.formatted));
+        .some(formatted => isPrevDate(date.formatted, formatted));
     },
     isOneDayBeforeFirst(date) {
       const first = this.selectedDates[0];
-      return first && isPrevDate(first.formatted, date.formatted);
+      return first && isPrevDate(date.formatted, first.formatted);
     },
     isOneDayAfterFirst(date) {
       const first = this.selectedDates[0];
@@ -346,7 +348,7 @@ export default {
     },
     isOneDayBeforeLast(date) {
       const last = this.selectedDates[1];
-      return last && isPrevDate(last.formatted, date.formatted);
+      return last && isPrevDate(date.formatted, last.formatted);
     },
     isOneDayAfterLast(date) {
       const last = this.selectedDates[1];

--- a/lib/utils/renderless-date.service.js
+++ b/lib/utils/renderless-date.service.js
@@ -34,31 +34,31 @@ export function isWeekend(date) {
   return day === SUNDAY || day === SATURDAY;
 }
 
-export function isPrevDate(date, comparedDate) {
-  return isOneDayDifference(comparedDate, date);
+export function isPrevDate(date, referenceDate) {
+  return isOneDayAfter(referenceDate, date);
 }
 
-export function isNextDate(date, comparedDate) {
-  return isOneDayDifference(date, comparedDate);
+export function isNextDate(date, referenceDate) {
+  return isOneDayAfter(date, referenceDate);
 }
 
-export function isOneDayDifference(date, comparedDate) {
+export function isOneDayAfter(date, referenceDate) {
   const date1 = fromFormatted(date).valueOf();
-  const date2 = fromFormatted(comparedDate).valueOf();
+  const date2 = fromFormatted(referenceDate).valueOf();
 
   return date1 - date2 === MILLISECONDS_IN_DAY;
 }
 
-export function isLessThan(date, comparedDate) {
-  return date < comparedDate;
+export function isLessThan(date, referenceDate) {
+  return date < referenceDate;
 }
 
-export function isGreaterThan(date, comparedDate) {
-  return date > comparedDate;
+export function isGreaterThan(date, referenceDate) {
+  return date > referenceDate;
 }
 
-export function isEqual(date, comparedDate) {
-  return date === comparedDate;
+export function isEqual(date, referenceDate) {
+  return date === referenceDate;
 }
 
 export function isSameMonth(month1, month2) {


### PR DESCRIPTION
Some classes utility method such as `isOneDayAfter` and so were reversed, so the classes applied to the component were wrong.

Also, it was hard to style the hovered cells while selecting the second date in range mode.  
So I chose to set it as selected even though it's not clicked yet (only on *range mode* when the first date is already selected).

Feel free to ask questions about this one!

Note: I should have added unit tests for this. I'll do it later I guess.