### PR TITLE
Localization: add hard-coded kk localization since it is not fully supported in all browsers

### DIFF
--- a/lib/locale/kz.js
+++ b/lib/locale/kz.js
@@ -1,0 +1,88 @@
+const months = [
+  {
+    short: 'Қаң',
+    full: 'Қаңтар',
+  },
+  {
+    short: 'Ақп',
+    full: 'Ақпан',
+  },
+  {
+    short: 'Нау',
+    full: 'Наурыз',
+  },
+  {
+    short: 'Сәу',
+    full: 'Сәуір',
+  },
+  {
+    short: 'Мам',
+    full: 'Мамыр',
+  },
+  {
+    short: 'Мау',
+    full: 'Маусым',
+  },
+  {
+    short: 'Шіл',
+    full: 'Шілде',
+  },
+  {
+    short: 'Там',
+    full: 'Тамыз',
+  },
+  {
+    short: 'Қыр',
+    full: 'Қыркүйек',
+  },
+  {
+    short: 'Қаз',
+    full: 'Қазан',
+  },
+  {
+    short: 'Қар',
+    full: 'Қараша',
+  },
+  {
+    short: 'Жел',
+    full: 'Желтоқсан',
+  },
+];
+
+const days = [
+  {
+    short: 'Дс',
+    full: 'Дүйсенбі',
+  },
+  {
+    short: 'Сс',
+    full: 'Сейсенбі',
+  },
+  {
+    short: 'Сә',
+    full: 'Сәрсенбі',
+  },
+  {
+    short: 'Бс',
+    full: 'Бейсенбі',
+  },
+  {
+    short: 'Жм',
+    full: 'Жұма',
+  },
+  {
+    short: 'Сб',
+    full: 'Сенбі',
+  },
+  {
+    short: 'Жс',
+    full: 'Жексенбі',
+  },
+];
+
+const locale = {
+  months,
+  days,
+};
+
+export default locale;


### PR DESCRIPTION
Add kz locale, since `.toLocaleString` with kk locale is not supported in Google Chrome

@winexy 